### PR TITLE
Display error message when adding instructor

### DIFF
--- a/src/web/app/pages-admin/admin-home-page/admin-home-page.component.html
+++ b/src/web/app/pages-admin/admin-home-page/admin-home-page.component.html
@@ -38,6 +38,8 @@
     <div class="top-padded">
       <button class="btn btn-primary" id="add-instructor" (click)="validateAndAddInstructorDetail()">Add Instructor</button>
     </div>
+
+    <div class="top-padded" style="color: red" *ngIf="error.hasError">{{error.errorMessage}}</div>
   </div>
 </div>
 

--- a/src/web/app/pages-admin/admin-home-page/admin-home-page.component.ts
+++ b/src/web/app/pages-admin/admin-home-page/admin-home-page.component.ts
@@ -33,6 +33,8 @@ export class AdminHomePageComponent {
 
   isAddingInstructors: boolean = false;
 
+  error:any = { hasError:false, errorMessage:'' };
+
   constructor(private accountService: AccountService) {}
 
   /**
@@ -68,8 +70,22 @@ export class AdminHomePageComponent {
   validateAndAddInstructorDetail(): void {
     if (!this.instructorName || !this.instructorEmail || !this.instructorInstitution) {
       // TODO handle error
+      this.error = { hasError:true, errorMessage:'Please fill in all the fields' };
       return;
     }
+
+    for (let i = 0; i < this.instructorsConsolidated.length; i++) {
+      const instructor: InstructorData = this.instructorsConsolidated[i];
+      if (this.instructorName === instructor.name 
+        && this.instructorEmail === instructor.email 
+        && this.instructorInstitution === instructor.institution) {
+        this.error = { hasError:true, errorMessage:'Instructor already added to Result section' };
+        return;    
+	  }
+	}
+
+    this.error = { hasError:false, errorMessage:'' };
+
     this.instructorsConsolidated.push({
       name: this.instructorName,
       email: this.instructorEmail,


### PR DESCRIPTION
Problem: The webpage does not show any message to admins who are adding a single instructor.

Displays error message when admin is adding instructors.
Checks whether an instructor is already in the result section and displays an error message `Instructor already added to Result section` if so.

![image](https://user-images.githubusercontent.com/58677983/109291616-25bae480-7864-11eb-9b58-acdb11f97e1f.png)


Also displays an error message `Please fill in all the fields` when there are empty fields.

![image](https://user-images.githubusercontent.com/58677983/109291722-42efb300-7864-11eb-8410-f4a9814bc38a.png)

